### PR TITLE
Switch the git url to https:// instead of git+https://

### DIFF
--- a/advisories/2016/OSEC-2016-01.md
+++ b/advisories/2016/OSEC-2016-01.md
@@ -5,7 +5,7 @@ published: "2016-04-29T00:18:22Z"
 aliases: [ CVE-2015-8869 ]
 affected: "ocaml" {< "4.03.0"}
 events: [
-  git "git+https://github.com/ocaml/ocaml" [
+  git "https://github.com/ocaml/ocaml" [
     [fixed "659615c7b100a89eafe6253e7a5b9d84d0e8df74"]
   ]
 ]

--- a/advisories/2016/OSEC-2016-02.md
+++ b/advisories/2016/OSEC-2016-02.md
@@ -4,7 +4,7 @@ modified: "2026-01-13T12:00:00Z"
 published: "2016-05-03T00:00:00Z"
 affected: "mirage-net-xen" {< "1.4.2"}
 events: [
-  git "git+https://github.com/mirage/mirage-net-xen" [
+  git "https://github.com/mirage/mirage-net-xen" [
     [fixed "0b1e53c0875062a50e2d5823b7da0d8e0a64dc37"]
   ]
 ]

--- a/advisories/2017/OSEC-2017-01.md
+++ b/advisories/2017/OSEC-2017-01.md
@@ -5,7 +5,7 @@ published: "2017-06-23T15:19:47Z"
 aliases: [ CVE-2017-9772 ]
 affected: "ocaml" {>= "4.04" & < "4.04.2"}
 events: [
-  git "git+https://github.com/ocaml/ocaml" [
+  git "https://github.com/ocaml/ocaml" [
     [introduced "507507829e9639374ede5a2dade1bb6d6b98ad49"]
     [fixed "850021c200c7507f2a928a66fa1291ff4ae3a622"]
   ]

--- a/advisories/2018/OSEC-2018-01.md
+++ b/advisories/2018/OSEC-2018-01.md
@@ -7,7 +7,7 @@ severity: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 severity_score: "9.8 (Critical)"
 affected: "ocaml" {< "4.07.0"}
 events: [
-  git "git+https://github.com/ocaml/ocaml" [
+  git "https://github.com/ocaml/ocaml" [
     [fixed "9664c7ee807c2dfa802f53cabd405ff58e219c47"]
   ]
 ]

--- a/advisories/2019/OSEC-2019-01.md
+++ b/advisories/2019/OSEC-2019-01.md
@@ -4,7 +4,7 @@ modified: "2026-01-13T12:00:00Z"
 published: "2019-03-21T00:00:00Z"
 affected: "netchannel" {>= "1.10.0" & < "1.10.1"}
 events: [
-  git "git+https://github.com/mirage/mirage-net-xen" [
+  git "https://github.com/mirage/mirage-net-xen" [
     [introduced "e4f8d9f65a7999ac259cea57395bf5fbf00773bb"]
     [fixed "bdfc658f139e39cdf1b8dada013b91df67a8e26a"]
   ]

--- a/advisories/2019/OSEC-2019-02.md
+++ b/advisories/2019/OSEC-2019-02.md
@@ -4,7 +4,7 @@ modified: "2026-01-13T12:00:00Z"
 published: "2019-04-26T00:00:00Z"
 affected: "mirage-xen" {< "3.3.0"}
 events: [
-  git "git+https://github.com/mirage/mirage-xen" [
+  git "https://github.com/mirage/mirage-xen" [
     [fixed "f86e173922233568158c605ab98add623bedf948"]
   ]
 ]

--- a/advisories/2022/OSEC-2022-01.md
+++ b/advisories/2022/OSEC-2022-01.md
@@ -5,7 +5,7 @@ published: "2022-12-07T00:00:00Z"
 aliases: [ CVE-2022-46770 ]
 affected: "solo5" {>= "0.6.6" & < "0.7.5"}
 events: [
-  git "git+https://github.com/mirage/mirage-xen" [
+  git "https://github.com/mirage/mirage-xen" [
     [introduced "f4b47d11983bf8f32aaf4ec496a045c35e4e582f"]
     [fixed "f86e173922233568158c605ab98add623bedf948"]
   ]

--- a/advisories/2023/OSEC-2023-01.md
+++ b/advisories/2023/OSEC-2023-01.md
@@ -4,7 +4,7 @@ modified: "2026-01-09T12:00:00Z"
 published: "2023-05-25T12:00:00Z"
 affected: "opam-repository" {>= "2" & < "2.1.5"}
 events: [
-  git "git+https://github.com/ocaml/opam" [
+  git "https://github.com/ocaml/opam" [
     [introduced "cfa4e77b49d0bccaf5c91b2e6f36089aab5e0540"]
     [fixed "7a538fd0bf3b3956d84bb25d0f6b1126fa177595"]
   ]

--- a/advisories/2025/OSEC-2025-01.md
+++ b/advisories/2025/OSEC-2025-01.md
@@ -4,7 +4,7 @@ modified: "2026-01-13T12:00:00Z"
 published: "2025-08-15T00:18:22Z"
 affected: "albatross" {< "2.5.0"}
 events: [
-  git "git+https://github.com/robur-coop/albatross" [
+  git "https://github.com/robur-coop/albatross" [
     [fixed "d01805796ec710691a701c01ed3f0e4cd284a161"]
   ]
 ]


### PR DESCRIPTION
This should allow osv.dev to not choke on our advisories

To mitigate https://github.com/google/osv.dev/pull/4632#issuecomment-3857284123 @another-rex