### PR TITLE
OSEC-2026-10: Fix an off-by-one date drift

### DIFF
--- a/advisories/2026/OSEC-2026-10.md
+++ b/advisories/2026/OSEC-2026-10.md
@@ -57,4 +57,4 @@ Installing this package will write the `pwnd` file in the home directory of the 
 
 - 2026-05-15: Kate reported the issue to the rest of the opam team and the OCaml Security team
 - 2026-06-22: Nathan wrote a fix which was then reviewed by Raja and refined over the next 2 weeks
-- 2026-07-07: opam 2.5.2 was released with the fix
+- 2026-07-08: opam 2.5.2 was released with the fix


### PR DESCRIPTION
The release was tagged yesterday, not the day before. I forgot to update it before https://github.com/ocaml/security-advisories/pull/28 was merged.